### PR TITLE
Alterações para serviços e afins

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -19,7 +19,7 @@ detectors:
   DuplicateMethodCall:
     enabled: true
     exclude: []
-    max_calls: 1
+    max_calls: 2
     allow_calls: []
   FeatureEnvy:
     enabled: false

--- a/.reek.yml
+++ b/.reek.yml
@@ -22,13 +22,13 @@ detectors:
     max_calls: 1
     allow_calls: []
   FeatureEnvy:
-    enabled: true
+    enabled: false
     exclude: []
   InstanceVariableAssumption:
     enabled: true
     exclude: []
   IrresponsibleModule:
-    enabled: true
+    enabled: false
     exclude: []
   LongParameterList:
     enabled: true
@@ -73,7 +73,7 @@ detectors:
   TooManyInstanceVariables:
     enabled: true
     exclude: []
-    max_instance_variables: 4
+    max_instance_variables: 6
   TooManyMethods:
     enabled: true
     exclude: []
@@ -125,7 +125,7 @@ detectors:
   UtilityFunction:
     enabled: true
     exclude: []
-    public_methods_only: false
+    public_methods_only: true
 exclude_paths:
   - "config/"
   - "db/"


### PR DESCRIPTION
Pode ser que os parâmetros do `reek` ainda estejam um pouco exigentes e/ou nos façam programar mais para que evitemos ativá-lo.

Exemplos:

`FeatureEnvy`: se recebo uma configuração e gostaria de ler como métodos (imagine um `HashWithIndifferentAccess`) e tenho: `config.x` `config.y` `config.z` no mesmo método, é arriscado que o `FeatureEnvy` dispare sem necessidade. De qualquer forma, precisamos manualmente ter ciência de que métodos são usados para leitura e quais efetivamente podem, por exemplo, bater mais uma vez no banco de dados.

`IrresponsibleModule` pode fazer com que documentemos coisas óbvias. Não sei ao certo qual a política, mas dado a comum não documentação dos métodos, poderíamos zelar por cautela e fazer um esforço para documentar onde teremos mais impacto.

`TooManyInstanceVariables` sendo 4 nos dificulta criar serviços com mais de 4 `attr_reader`, por exemplo. Podemos receber hashes como parâmetro, mas isto obrigaria-nos a fazer isto em certos cenários, dando menos transparência ao módulo que estamos fazendo.

`UtilityFunction` é comum fazermos volta e meia, e talvez possamos fazer com que um meio termo seja alcançado apenas ativando este `reek` em métodos públicos. Caso contrário, simplificar certas rotinas pode ficar muito tedioso ou porque não podemos praticar DRY suficientemente (pense num mini parser de configurações) e talvez tenhamos de ficar barganhando por número de linhas de código e talvez fazer códigos menos legíveis com isso, já que há outros cops que reclamam de número de linhas por método ou número de statements por método.

`DuplicateMethodCall` pode acontecer eventualmente, especialmente se estamos vendo hashes. Claro que pode ser um sinal de alerta se chamarmos o banco de dados duas vezes, mas pode fazer com que gastemos muitas linhas apenas declarando variáveis, especialmente de hashes (with_indifferent_access acessados como "métodos"), apenas para escapar deste cop. Seria ideal podermos fazer a mesma chamada talvez 2 vezes (sugerido).